### PR TITLE
Update MCMC_generation_interval.R

### DIFF
--- a/MCMC_generation_interval.R
+++ b/MCMC_generation_interval.R
@@ -210,7 +210,7 @@ hist(inc1); hist(inc2)
 xg=rgamma(n,shape=5.20^2/1.72^2,rate=5.20/1.72^2)
 hist(xg)
 mean(xg)
-xs=xg+inc1-inc2
+xs=xg+inc2-inc1
 hist(xs)
 mean(xs); quantile(xs, c(0.025,0.5,0.975))
 sd(xs)


### PR DESCRIPTION
`inc1` and `inc2` switched. It doesn't affect the calculation as they share the same Gamma distribution but it helps in the understanding since `inc1` denotes the incubation period of the infector and `inc2` the infectee. ps thanks for the great paper. I'm hoping to use its SI & GT estimates soon.